### PR TITLE
Entity scan on non-existing data model package silences error

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/DefaultClassScanner.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/DefaultClassScanner.java
@@ -47,13 +47,18 @@ public class DefaultClassScanner implements ClassScanner {
 
     @Override
     public Set<Class<?>> getAnnotatedClasses(String packageName, Class<? extends Annotation> annotation) {
-        return startupCache.get(annotation.getCanonicalName()).stream()
-                .filter(clazz ->
-                        clazz.getPackage().getName().equals(packageName)
-                                || clazz.getPackage().getName().startsWith(packageName + "."))
+        LinkedHashSet<Class<?>> annotatedClasses = startupCache.get(annotation.getCanonicalName()).stream()
+                .filter(clazz -> clazz.getPackage().getName().equals(packageName)
+                        || clazz.getPackage().getName().startsWith(packageName + "."))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
 
+        // Check if the annotated class collection obtained is empty
+        if (annotatedClasses.isEmpty()) {
+            throw new IllegalArgumentException("No annotated classes found in the specified package: " + packageName);
+        }
+
+        return annotatedClasses;
+    }
     @Override
     public Set<Class<?>> getAnnotatedClasses(List<Class<? extends Annotation>> annotations,
             FilterExpression filter) {


### PR DESCRIPTION
Resolves #1

## Description
This PR primarily addresses the scenario where Elide is configured with a non-existent data model package. With the updated implementation, `Elide` now fails to start gracefully and throws a runtime exception when encountering an invalid data model package during scanning.

## Motivation and Context
In the `Standalone`, the `getAnnotatedClasses` of the `DefaultClassScanner` under the` Elide` is called to scan the package. I add a judgment on the Set, and throw an exception if it is empty.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.