### PR TITLE
Fix GraphQL mutation with Fragment not being treated as mutation

### DIFF
--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -64,6 +64,7 @@ public class QueryRunner {
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
     private static final String FRAGMENT = "fragment";
+    public  static final String patternString = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
 
     /**
      * Builds a new query runner.
@@ -140,7 +141,6 @@ public class QueryRunner {
         if (query.startsWith(FRAGMENT)) {
             //Use a regular expression to match "}(any amount of whitespace)*mutation".
             //There can be only Spaces between "}" and "mutation", and no other characters
-            String patternString = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
             Pattern pattern = Pattern.compile(patternString, Pattern.UNICODE_CHARACTER_CLASS);
             Matcher matcher = pattern.matcher(query);
 

--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -64,7 +64,7 @@ public class QueryRunner {
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
     private static final String FRAGMENT = "fragment";
-    public  static final String patternString = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
+    public  static final String PATTERN_STRING = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
 
     /**
      * Builds a new query runner.
@@ -141,7 +141,7 @@ public class QueryRunner {
         if (query.startsWith(FRAGMENT)) {
             //Use a regular expression to match "}(any amount of whitespace)*mutation".
             //There can be only Spaces between "}" and "mutation", and no other characters
-            Pattern pattern = Pattern.compile(patternString, Pattern.UNICODE_CHARACTER_CLASS);
+            Pattern pattern = Pattern.compile(PATTERN_STRING, Pattern.UNICODE_CHARACTER_CLASS);
             Matcher matcher = pattern.matcher(query);
 
             //Find the first match

--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -43,6 +43,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Entry point for REST endpoints to execute GraphQL queries.
@@ -61,6 +63,9 @@ public class QueryRunner {
     private static final String OPERATION_NAME = "operationName";
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
+    private static final String FRAGMENT = "fragment";
+    private static final Pattern MUTATION_PATTERN = Pattern.compile("(?<=\\}\\s*)" + Pattern.quote(MUTATION),
+            Pattern.UNICODE_CHARACTER_CLASS);
 
     /**
      * Builds a new query runner.
@@ -134,6 +139,16 @@ public class QueryRunner {
 
         query = withoutComments.toString().trim();
 
+        if (query.startsWith(FRAGMENT)) {
+            //Use a regular expression to match "}(any amount of whitespace)*mutation".
+            Matcher matcher = MUTATION_PATTERN.matcher(query);
+
+            //Find the first match
+            if (matcher.find()) {
+                //Returns the portion of the string starting with the matched "mutation"
+                query =  query.substring(matcher.start());
+            }
+        }
         return query.startsWith(MUTATION);
     }
 

--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -40,6 +40,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -64,7 +65,7 @@ public class QueryRunner {
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
     private static final String FRAGMENT = "fragment";
-    public  static final String PATTERN_STRING = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
+    private static final String PATTERN_STRING = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
 
     /**
      * Builds a new query runner.

--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -40,7 +40,6 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -64,8 +64,6 @@ public class QueryRunner {
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
     private static final String FRAGMENT = "fragment";
-    private static final Pattern MUTATION_PATTERN = Pattern.compile("(?<=\\}\\s*)" + Pattern.quote(MUTATION),
-            Pattern.UNICODE_CHARACTER_CLASS);
 
     /**
      * Builds a new query runner.
@@ -141,7 +139,10 @@ public class QueryRunner {
 
         if (query.startsWith(FRAGMENT)) {
             //Use a regular expression to match "}(any amount of whitespace)*mutation".
-            Matcher matcher = MUTATION_PATTERN.matcher(query);
+            //There can be only Spaces between "}" and "mutation", and no other characters
+            String patternString = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
+            Pattern pattern = Pattern.compile(patternString, Pattern.UNICODE_CHARACTER_CLASS);
+            Matcher matcher = pattern.matcher(query);
 
             //Find the first match
             if (matcher.find()) {

--- a/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/paiondata/elide/graphql/QueryRunner.java
@@ -64,7 +64,8 @@ public class QueryRunner {
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
     private static final String FRAGMENT = "fragment";
-    private static final String PATTERN_STRING = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
+    private static final String PATTERN_REGEX = "(?<=\\}\\s*)" + Pattern.quote(MUTATION);
+    private static final Pattern PATTERN = Pattern.compile(PATTERN_REGEX, Pattern.UNICODE_CHARACTER_CLASS);
 
     /**
      * Builds a new query runner.
@@ -141,8 +142,7 @@ public class QueryRunner {
         if (query.startsWith(FRAGMENT)) {
             //Use a regular expression to match "}(any amount of whitespace)*mutation".
             //There can be only Spaces between "}" and "mutation", and no other characters
-            Pattern pattern = Pattern.compile(PATTERN_STRING, Pattern.UNICODE_CHARACTER_CLASS);
-            Matcher matcher = pattern.matcher(query);
+            Matcher matcher = PATTERN.matcher(query);
 
             //Find the first match
             if (matcher.find()) {

--- a/elide-graphql/src/test/java/com/paiondata/elide/graphql/QueryRunnerTest.java
+++ b/elide-graphql/src/test/java/com/paiondata/elide/graphql/QueryRunnerTest.java
@@ -68,6 +68,28 @@ public class QueryRunnerTest extends GraphQLTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "fragment CoreFields { ... }\nmutation { ... }",
+            "fragment OtherFields { ... }\n\nmutation { ... }",
+            "   fragment SomeFields { ... }\n\nmutation { ... }",
+            "fragment MultipleFragments { ... }\n  fragment AnotherFragment { ... }\nmutation { ... }"
+    })
+    public void testIsMutationWithFragmentBefore(String input) {
+        assertTrue(QueryRunner.isMutation(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "mutation { ... } fragment LaterFields { ... }",
+            "mutation { ... }\nfragment AnotherLater { ... }",
+            "mutation { ... }\n\n   fragment FarLater { ... }",
+            "mutation { ... }\nfragment OneMore { ... }\nfragment AndAnother { ... }"
+    })
+    public void testIsMutationWithFragmentAfter(String input) {
+        assertTrue(QueryRunner.isMutation(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
             "#abcd\n  #befd\n query",
             "query",
             "QUERY",


### PR DESCRIPTION
## Description
#21 
Tests are added for the two cases of fragment use under mutation respectively.

We added a condition that if the processed string starts with `"fragment"`, we take the last `"}"` and the `"mutation"` string that starts with the `"mutation"` character and has no characters between it and the closing brace other than whitespace.